### PR TITLE
Handle newer firmware with heating zone support

### DIFF
--- a/owl.js
+++ b/owl.js
@@ -171,16 +171,26 @@ OWL.prototype.monitor = function ( ) {
 			self.emit( 'electricity', JSON.stringify(electricity) );		
 		
 	 	} else if ( buff.heating ) {
-		    var heating = { 'id':buff.heating.id,
-							'signal':buff.heating.signal,
-							'battery':buff.heating.battery.level,
-							'temperature':buff.heating.temperature };
-		
-			self.emit( 'heating', JSON.stringify(heating) );
-		
+			if(buff.heating.zones && buff.heating.zones.zone)
+      {
+        var heating = { 'id':buff.heating.id,
+                'signal':buff.heating.zones.zone.signal,
+                'battery':buff.heating.zones.zone.battery.level,
+                'temperature':buff.heating.zones.zone.temperature };
+      
+        self.emit( 'heating', JSON.stringify(heating) );
+      }
+      else
+      {
+        var heating = { 'id':buff.heating.id,
+                'signal':buff.heating.signal,
+                'battery':buff.heating.battery.level,
+                'temperature':buff.heating.temperature };
+      
+        self.emit( 'heating', JSON.stringify(heating) );
+      }
 	 	} else if ( buff.weather ) {
 			self.emit( 'weather', JSON.stringify(buff.weather) );
-		
 		} else if ( buff.solar ) {
 			var solar = { 'id':buff.solar.id,
 						  'current':[{'generating':buff.solar.current.generating.$t,'units':buff.solar.current.generating.units},

--- a/owl.js
+++ b/owl.js
@@ -172,24 +172,24 @@ OWL.prototype.monitor = function ( ) {
 		
 	 	} else if ( buff.heating ) {
 			if(buff.heating.zones && buff.heating.zones.zone)
-      {
-        var heating = { 'id':buff.heating.id,
-                'signal':buff.heating.zones.zone.signal,
-                'battery':buff.heating.zones.zone.battery.level,
-                'temperature':buff.heating.zones.zone.temperature };
-      
-        self.emit( 'heating', JSON.stringify(heating) );
-      }
-      else
-      {
-        var heating = { 'id':buff.heating.id,
-                'signal':buff.heating.signal,
-                'battery':buff.heating.battery.level,
-                'temperature':buff.heating.temperature };
-      
-        self.emit( 'heating', JSON.stringify(heating) );
-      }
-	 	} else if ( buff.weather ) {
+			{
+				var heating = { 'id':buff.heating.id,
+								'signal':buff.heating.zones.zone.signal,
+								'battery':buff.heating.zones.zone.battery.level,
+								'temperature':buff.heating.zones.zone.temperature };
+
+				self.emit( 'heating', JSON.stringify(heating) );
+			}
+			else
+			{
+				var heating = { 'id':buff.heating.id,
+								'signal':buff.heating.signal,
+								'battery':buff.heating.battery.level,
+								'temperature':buff.heating.temperature };
+
+				self.emit( 'heating', JSON.stringify(heating) );
+			 }
+		} else if ( buff.weather ) {
 			self.emit( 'weather', JSON.stringify(buff.weather) );
 		} else if ( buff.solar ) {
 			var solar = { 'id':buff.solar.id,


### PR DESCRIPTION
This changes handles messages from newer firmware that supports zones. This will probably only work with a single zone and just sends events that match the original API.